### PR TITLE
X11 improvements

### DIFF
--- a/Engine/system/api/x11api.cpp
+++ b/Engine/system/api/x11api.cpp
@@ -205,7 +205,7 @@ SystemApi::Window *X11Api::implCreateWindow(Tempest::Window *owner, SystemApi::S
       hwnd = implCreateWindow(owner,800, 600);
       break;
     case Minimized:
-    case Maximized
+    case Maximized:
       // TODO
       hwnd = implCreateWindow(owner,width, height);
       break;

--- a/Engine/system/api/x11api.cpp
+++ b/Engine/system/api/x11api.cpp
@@ -274,6 +274,8 @@ void X11Api::implSetCursorPosition(int x, int y) {
   }
 
 void X11Api::implShowCursor(bool show) {
+  if(windows.size()==0)
+    return;
   if(show) {
     XUndefineCursor(dpy, HWND(windows.begin()->first));
     } else {
@@ -375,6 +377,7 @@ void X11Api::implProcessEvents(SystemApi::AppCallBack &cb) {
         }
       case MotionNotify: {
         if(activeCursorChange == 1) {
+          // FIXME: mouse behave crazy in OpenGothic
           activeCursorChange = 0;
           break;
         }

--- a/Engine/system/api/x11api.cpp
+++ b/Engine/system/api/x11api.cpp
@@ -12,7 +12,6 @@
 #include <Tempest/Event>
 #include <Tempest/TextCodec>
 #include <Tempest/Window>
-#include <Tempest/Log>
 
 #include <atomic>
 #include <stdexcept>


### PR DESCRIPTION
This is a work in progress implementation for a few of the missing X11 graphics features, mainly full screen and cursor support.

The X11 fullscreen and isFullScreen should now work, along with the cursor hiding.

I had some questions regarding the rest:

- What's the recommended way to log in this project, such as a project utility to do so? Was mainly just wanting to log out when the isFullScreen had been called for temporary debug purposes.
- For the game to go fullscreen, I had to manually add a setAsFullscreen function call when the window was being created. It appears that that would normally occur automatically, since I didn't pass in the windowed flag. Could there be an issue with my implementation of looking for the full screen flag?
- I attempted to implement implSetCursorPosition but it just caused the mouse to go crazy and for the keyboard input to no longer work (couldn't use the w and s keys to navigate the menu). When is this function usually called? I saw some times where if it gets mouse movement, it calls back to re-center it. I'm wondering if it might be being called too often for Linux, or something might be wrong with an event getting propagated too much (as in if the manual mouse move could trigger another event, and so on).