### PR TITLE
Remove BYPRODUCTS from cmake custom commands

### DIFF
--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -125,7 +125,6 @@ function(add_shader OUTPUT SOURCE)
   list(SUBLIST ARGV 2 -1 VARS)
   add_custom_command(
     OUTPUT     ${OUTPUT_FILE}
-    BYPRODUCTS ${OUTPUT_FILE}
     DEPENDS    ${SOURCE_FILE}
     COMMAND    ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/sprv/"
     COMMAND    ${GLSLANGVALIDATOR} -V ${VARS} "${SOURCE_FILE}" -o ${OUTPUT_FILE}
@@ -141,7 +140,6 @@ add_shader(tex_brush.frag.sprv tex_brush.frag "")
 
 add_custom_command(
   OUTPUT     ${GEN_SHADERS_HEADER}
-  BYPRODUCTS ${GEN_SHADERS_HEADER}
   DEPENDS    ${SHADERS_SPRV}
   COMMAND    ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/sprv/"
   COMMAND    ${CMAKE_COMMAND} -P "${PROJECT_SOURCE_DIR}/shaders/link_shaders.cmake"


### PR DESCRIPTION
fixes ninja build error

   ninja: error: build.ninja:5663: multiple rules generate lib/MoltenTempest/Engine/sprv/builtin_shader.h [-w dupbuild=err]

cmake documentation sounds like BYPRODUCTS is supposed to be used for intermediate files,
not final outputs. It expliclity says "Byproducts may not be listed as outputs"
https://cmake.org/cmake/help/latest/policy/CMP0058.html